### PR TITLE
Fix encryption settings failing to load, and soften harmless warnings

### DIFF
--- a/lib/functions/snackbar.dart
+++ b/lib/functions/snackbar.dart
@@ -7,10 +7,11 @@ import 'package:adguard_home_manager/config/globals.dart';
 
 void showSnackbar({
   required AppConfigProvider appConfigProvider,
-  required String label, 
+  required String label,
   required Color color,
   Color? labelColor,
   GlobalKey<ScaffoldMessengerState>? key,
+  Duration? duration,
 }) async {
   final GlobalKey<ScaffoldMessengerState> scaffoldKey = key ?? scaffoldMessengerKey;
   if (appConfigProvider.showingSnackbar == true) {
@@ -27,6 +28,9 @@ void showSnackbar({
       ),
     ),
     backgroundColor: color,
+    // Leaving this null keeps the framework default of four seconds, which is
+    // what every existing call relies on.
+    duration: duration ?? const Duration(seconds: 4),
   );
   scaffoldKey.currentState?.showSnackBar(snackBar).closed.then(
     (value) => appConfigProvider.setShowingSnackbar(false)

--- a/lib/models/encryption.dart
+++ b/lib/models/encryption.dart
@@ -19,8 +19,8 @@ class EncryptionData {
   final bool validChain;
   final String? subject;
   final String? issuer;
-  final DateTime notBefore;
-  final DateTime notAfter;
+  final DateTime? notBefore;
+  final DateTime? notAfter;
   final List<String> dnsNames;
   final bool validKey;
   final String? keyType;
@@ -46,8 +46,8 @@ class EncryptionData {
     required this.validChain,
     this.subject,
     this.issuer,
-    required this.notBefore,
-    required this.notAfter,
+    this.notBefore,
+    this.notAfter,
     required this.dnsNames,
     required this.validKey,
     this.keyType,
@@ -70,18 +70,30 @@ class EncryptionData {
   });
 
 
+  /// Fields the API may leave out are read with a fallback to the zero value
+  /// they stand for.
+  ///
+  /// allow_unencrypted_doh is the reason this matters: AdGuard Home moved that
+  /// setting out of the TLS section into http.doh.insecure_enabled with schema
+  /// version 34, so /tls/status has not carried it since v0.108.0-b.84.
+  /// Reading it as a non-nullable bool threw on every such server and left the
+  /// encryption screen stuck on an error with no way to tell why.
+  ///
+  /// The remaining fallbacks are defensive. Most of those fields are always
+  /// present today, but a few carry omitempty, and this bug is what an API
+  /// change looks like when the client insists on a field.
   factory EncryptionData.fromJson(Map<String, dynamic> json) => EncryptionData(
-    validCert: json["valid_cert"],
-    validChain: json["valid_chain"],
+    validCert: json["valid_cert"] ?? false,
+    validChain: json["valid_chain"] ?? false,
     subject: json["subject"],
     issuer: json["issuer"],
-    notBefore: DateTime.parse(json["not_before"]),
-    notAfter: DateTime.parse(json["not_after"]),
+    notBefore: json["not_before"] == null ? null : DateTime.parse(json["not_before"]),
+    notAfter: json["not_after"] == null ? null : DateTime.parse(json["not_after"]),
     dnsNames: json["dns_names"] != null ? List<String>.from(json["dns_names"].map((x) => x)) : [],
-    validKey: json["valid_key"],
+    validKey: json["valid_key"] ?? false,
     keyType: json["key_type"],
-    validPair: json["valid_pair"],
-    enabled: json["enabled"],
+    validPair: json["valid_pair"] ?? false,
+    enabled: json["enabled"] ?? false,
     serverName: json["server_name"],
     forceHttps: json["force_https"] ?? false,
     portHttps: json["port_https"],
@@ -89,12 +101,12 @@ class EncryptionData {
     portDnsOverQuic: json["port_dns_over_quic"],
     portDnscrypt: json["port_dnscrypt"],
     dnscryptConfigFile: json["dnscrypt_config_file"],
-    allowUnencryptedDoh: json["allow_unencrypted_doh"],
-    certificateChain: json["certificate_chain"],
-    privateKey: json["private_key"],
-    certificatePath: json["certificate_path"],
-    privateKeyPath: json["private_key_path"],
-    privateKeySaved: json["private_key_saved"],
+    allowUnencryptedDoh: json["allow_unencrypted_doh"] ?? false,
+    certificateChain: json["certificate_chain"] ?? "",
+    privateKey: json["private_key"] ?? "",
+    certificatePath: json["certificate_path"] ?? "",
+    privateKeyPath: json["private_key_path"] ?? "",
+    privateKeySaved: json["private_key_saved"] ?? false,
     servePlainDns: json["serve_plain_dns"],
   );
 
@@ -103,8 +115,8 @@ class EncryptionData {
     "valid_chain": validChain,
     "subject": subject,
     "issuer": issuer,
-    "not_before": notBefore.toIso8601String(),
-    "not_after": notAfter.toIso8601String(),
+    "not_before": notBefore?.toIso8601String(),
+    "not_after": notAfter?.toIso8601String(),
     "dns_names": List<dynamic>.from(dnsNames.map((x) => x)),
     "valid_key": validKey,
     "key_type": keyType,

--- a/lib/screens/settings/encryption/encryption.dart
+++ b/lib/screens/settings/encryption/encryption.dart
@@ -147,8 +147,15 @@ class _EncryptionSettingsState extends State<EncryptionSettings> {
       final data = result.content as EncryptionValidationResult;
       if (data.isObject == true) {
         final object = data.encryptionValidation!;
+        final hasWarning = object.warningValidation != null && object.warningValidation != '';
+        // A message that arrives while the certificate itself checks out is
+        // advice, not a failure. The web interface makes the same distinction
+        // before deciding how loudly to present it.
+        final certificateIsSound = object.validCert == true &&
+          object.validKey == true &&
+          object.validPair == true;
         setState(() {
-          if (object.warningValidation != null && object.warningValidation != '') {
+          if (hasWarning && !certificateIsSound) {
             _dataValidApi = false;
             validDataError = object.warningValidation;
           }
@@ -158,6 +165,14 @@ class _EncryptionSettingsState extends State<EncryptionSettings> {
           }
           certKeyValid = object;
         });
+        if (hasWarning && certificateIsSound) {
+          showSnackbar(
+            appConfigProvider: Provider.of<AppConfigProvider>(context, listen: false),
+            label: object.warningValidation!,
+            color: Colors.red,
+            duration: const Duration(seconds: 6),
+          );
+        }
       }
       else {
         setState(() {


### PR DESCRIPTION
Closes #178

**Fix the load failure.** `allow_unencrypted_doh` no longer exists in `/tls/status` since AdGuard Home v0.108.0-b.84, but `EncryptionData` read it as a non-nullable `bool` and threw. Fields the API may omit now fall back to the zero value they stand for - that is not a guess, it restores what the server left out. `not_before` and `not_after` became nullable for the same reason.

**Soften harmless warnings.** Opening the screen validates the settings, and any message coming back was shown as a permanent red error card. Most are advice rather than failure: a certificate without IP addresses in its SANs is valid, it only means DNS-over-TLS is not advertised via DDR. The web interface treats a message as a warning whenever `valid_cert`, `valid_key` and `valid_pair` hold; the same distinction is applied here. Such a warning now appears as a snackbar for six seconds, everything else keeps the card.

`showSnackbar` gained an optional `duration`; leaving it out keeps the previous four seconds for all existing callers.