### PR TITLE
Bump Kotlin to 2.2.20 for Flutter 3.44 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,3 +4,7 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
     plugins {
         id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
-        id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+        id "org.jetbrains.kotlin.android" version "2.2.20" apply false
     }
 }
 


### PR DESCRIPTION
Building the project with a current Flutter version fails before anything is compiled:

```
Error: Your project's Kotlin version (1.8.22) is lower than Flutter's
minimum supported version of 2.0.0.
```

Flutter has required Kotlin 2.0.0 or newer for a while now, and it stops warning from 2.2.20 on, which is why I picked that version. It stays inside the supported range of the toolchain already pinned here: Gradle 8.11.1 (7.6.3 to 8.14) and AGP 8.10.1 (7.3.1 to 8.10), so nothing else needs to move.

The two `gradle.properties` flags were written by the Flutter migrator during the same build.

`MainActivity` is the only Kotlin source in the project and compiles unchanged, as do all plugins. Tested with Flutter 3.44.8 on Android.